### PR TITLE
Remove superfluous afterSignXUrl props

### DIFF
--- a/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -1,5 +1,5 @@
 import {SignIn} from "@clerk/nextjs";
 
 export default function SignInPage() {
-    return <SignIn afterSignInUrl="/" afterSignUpUrl="/" />;
+    return <SignIn />;
 }


### PR DESCRIPTION
Props should be configured via env vars, not directly in React (at least for now)